### PR TITLE
ci: switch to kubewarden 4.0.0 actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rego.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rego.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
     with:
       oci-target: ghcr.io/${{ github.repository_owner }}/tests/raw-validation-opa-policy
       artifacthub: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,6 @@ name: Continuous integration
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rego.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rego.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
     with:
       artifacthub: false

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
 SOURCE_FILES := $(shell find . -type f -name '*.rego')
-# It's necessary to call cut because kwctl command does not handle version
-# starting with v.
-VERSION ?= $(shell git describe | cut -c2-)
 
 policy.wasm: $(SOURCE_FILES)
 	opa build -t wasm -e policy/main utility/policy.rego -o bundle.tar.gz policy.rego

--- a/metadata.yml
+++ b/metadata.yml
@@ -12,6 +12,7 @@ annotations:
   # kubewarden specific:
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/tests/raw-validation-opa-policy # must match release workflow oci-target
   io.kubewarden.policy.title: raw-validation-opa-policy
+  io.kubewarden.policy.version: 
   io.kubewarden.policy.description: An OPA policy that validates a raw request
   io.kubewarden.policy.author: "Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>"
   io.kubewarden.policy.url: https://github.com/kubewarden/raw-validation-opa-policy


### PR DESCRIPTION
By upgrading to this release, we don't have to keep track of
artifacthub-pkg.yml anymore.

Moreover, the version of the policy is now an annotation of the policy's
metadata.

Signed-off-by: Víctor Cuadrado Juan <vcuadradojuan@suse.de>
Co-authored-by: Flavio Castelli <fcastelli@suse.com>
